### PR TITLE
Pull update from original head fork (#2)

### DIFF
--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -178,7 +178,7 @@ static void mednafen_init(MednafenGameCore* current)
     //MDFNI_SetSetting("vb.instant_display_hack", "1"); // Display latency reduction hack
 
 	// SNES Faust settings
-	MDFNI_SetSettingB("snes_faust.spex", true);
+	MDFNI_SetSettingB("snes_faust.spex", false);
 	// Enable 1-frame speculative execution for video output.
 	// Hack to reduce input->output video latency by 1 frame. Enabling will increase CPU usage,
 	// and may cause video glitches(such as "jerkiness") in some oddball games, but most commercially-released games should be fine.

--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -497,7 +497,6 @@
 		B35BB800202F3F2200FCB513 /* PVRecentGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35BB7FA202F3F2100FCB513 /* PVRecentGame.swift */; };
 		B35D26FA20337D1C00F17D58 /* GameLaunchingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35D26F920337D1C00F17D58 /* GameLaunchingViewController.swift */; };
 		B35D26FB20337D1C00F17D58 /* GameLaunchingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35D26F920337D1C00F17D58 /* GameLaunchingViewController.swift */; };
-		B35D26FD2033977600F17D58 /* VolumeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35D26FC2033977500F17D58 /* VolumeBar.swift */; };
 		B35D27022033B44B00F17D58 /* PVGameMoreInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B385542D20336D02006CA50B /* PVGameMoreInfoViewController.swift */; };
 		B35E6C21207ED7050040709A /* AppearanceScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35E6C18207ED7030040709A /* AppearanceScope.swift */; };
 		B35E6C22207ED7050040709A /* AppearanceScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35E6C18207ED7030040709A /* AppearanceScope.swift */; };
@@ -798,6 +797,7 @@
 		BE9FDCB91C210B9E0046DF0E /* TVServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE9FDCB81C210B9E0046DF0E /* TVServices.framework */; };
 		BE9FDCBD1C210B9F0046DF0E /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9FDCBC1C210B9F0046DF0E /* ServiceProvider.swift */; };
 		BE9FDCC91C210C470046DF0E /* PVRecentGame+TopShelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9FDCC81C210C470046DF0E /* PVRecentGame+TopShelf.swift */; };
+		C6E8F64D2095CAE4003CC2D9 /* SubtleVolume.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E8F64C2095CAE4003CC2D9 /* SubtleVolume.swift */; };
 		DF0035C5203C97D900F63831 /* GLideN64.custom.ini in Resources */ = {isa = PBXBuildFile; fileRef = DF0035C4203C97D800F63831 /* GLideN64.custom.ini */; };
 		DF0035C6203C97E100F63831 /* GLideN64.custom.ini in Resources */ = {isa = PBXBuildFile; fileRef = DF0035C4203C97D800F63831 /* GLideN64.custom.ini */; };
 		DF0035C8203C97FA00F63831 /* GLideN64.ini in Resources */ = {isa = PBXBuildFile; fileRef = DF0035C7203C97FA00F63831 /* GLideN64.ini */; };
@@ -1422,7 +1422,6 @@
 		B35BB7F9202F3F2100FCB513 /* PVGame.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PVGame.swift; sourceTree = "<group>"; };
 		B35BB7FA202F3F2100FCB513 /* PVRecentGame.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PVRecentGame.swift; sourceTree = "<group>"; };
 		B35D26F920337D1C00F17D58 /* GameLaunchingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameLaunchingViewController.swift; sourceTree = "<group>"; };
-		B35D26FC2033977500F17D58 /* VolumeBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VolumeBar.swift; sourceTree = "<group>"; };
 		B35E6C18207ED7030040709A /* AppearanceScope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppearanceScope.swift; sourceTree = "<group>"; };
 		B35E6C19207ED7040040709A /* UIAppearanceExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIAppearanceExtensions.swift; sourceTree = "<group>"; };
 		B35E6C1A207ED7040040709A /* UIApplicationExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIApplicationExtensions.swift; sourceTree = "<group>"; };
@@ -1545,6 +1544,7 @@
 		BE9FDCC81C210C470046DF0E /* PVRecentGame+TopShelf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PVRecentGame+TopShelf.swift"; sourceTree = "<group>"; };
 		BE9FDCCC1C21109B0046DF0E /* Provenance.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Provenance.entitlements; sourceTree = "<group>"; };
 		BE9FDCCD1C21194B0046DF0E /* TopShelf.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = TopShelf.entitlements; sourceTree = "<group>"; };
+		C6E8F64C2095CAE4003CC2D9 /* SubtleVolume.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubtleVolume.swift; sourceTree = "<group>"; };
 		DF0035C4203C97D800F63831 /* GLideN64.custom.ini */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = GLideN64.custom.ini; path = "PVMupen64Plus/Plugins/mupen64plus-video-gliden64/ini/GLideN64.custom.ini"; sourceTree = "<group>"; };
 		DF0035C7203C97FA00F63831 /* GLideN64.ini */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = GLideN64.ini; path = "PVMupen64Plus/Plugins/mupen64plus-video-gliden64/ini/GLideN64.ini"; sourceTree = "<group>"; };
 		DFB603BA2038B6AF001E70F1 /* PVMupen64PlusVideoGlideN64.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PVMupen64PlusVideoGlideN64.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2878,7 +2878,7 @@
 				1A48696F17C8C0DE0019F6D2 /* PVGameLibraryCollectionViewCell.swift */,
 				42BC83A817E6775E00E9A607 /* PVGameLibrarySectionHeaderView.swift */,
 				B3F7BE78204A289B000D0B4D /* PVConflictViewController.swift */,
-				B35D26FC2033977500F17D58 /* VolumeBar.swift */,
+				C6E8F64C2095CAE4003CC2D9 /* SubtleVolume.swift */,
 				B385542D20336D02006CA50B /* PVGameMoreInfoViewController.swift */,
 				B35D26F920337D1C00F17D58 /* GameLaunchingViewController.swift */,
 				1A2FB108206EE8A700A1F942 /* PVSaveStatesViewController.swift */,
@@ -3532,6 +3532,7 @@
 				B3D8DD34206EAA9E008FAC42 /* ThreadSafeReference.swift in Sources */,
 				B3995E52205840CE001D4985 /* PlistDataModels.swift in Sources */,
 				B3E3B5D9202ED84100A11871 /* PVGameLibraryViewController.swift in Sources */,
+				C6E8F64D2095CAE4003CC2D9 /* SubtleVolume.swift in Sources */,
 				B349AE791E9ABCF900ACD416 /* Ppmd7.c in Sources */,
 				B349AE4F1E9ABCF900ACD416 /* 7zStream.c in Sources */,
 				B349AF091E9ABCF900ACD416 /* LzmaDecoder.cpp in Sources */,
@@ -3541,7 +3542,6 @@
 				B3E21D6620320E6F009939D3 /* Logging.swift in Sources */,
 				B349AE591E9ABCF900ACD416 /* Bcj2Enc.c in Sources */,
 				1FB125961D93E57F00D045D0 /* PVAppearanceViewController.swift in Sources */,
-				B35D26FD2033977600F17D58 /* VolumeBar.swift in Sources */,
 				B349AE4D1E9ABCF900ACD416 /* 7zFile.c in Sources */,
 				B349AE7F1E9ABCF900ACD416 /* Sha256.c in Sources */,
 				B349AE931E9ABCF900ACD416 /* 7zDecode.cpp in Sources */,

--- a/Provenance/Controller/PVControllerViewController.swift
+++ b/Provenance/Controller/PVControllerViewController.swift
@@ -20,6 +20,7 @@ protocol JSButtonDisplayer {
     var rightShoulderButton: JSButton? { get set }
     var leftShoulderButton2: JSButton? { get set }
     var rightShoulderButton2: JSButton? { get set }
+    var zTriggerButton: JSButton? { get set }
     var startButton: JSButton? { get set }
     var selectButton: JSButton? { get set }
 }
@@ -47,6 +48,7 @@ protocol ControllerVC: StartSelectDelegate, JSButtonDelegate, JSDPadDelegate whe
     var rightShoulderButton: JSButton? {get}
     var leftShoulderButton2: JSButton? {get}
     var rightShoulderButton2: JSButton? {get}
+    var zTriggerButton: JSButton? { get set }
     var startButton: JSButton? {get}
     var selectButton: JSButton? {get}
 
@@ -152,6 +154,7 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
     var rightShoulderButton: JSButton?
     var leftShoulderButton2: JSButton?
     var rightShoulderButton2: JSButton?
+    var zTriggerButton: JSButton?
     var startButton: JSButton?
     var selectButton: JSButton?
 
@@ -207,10 +210,12 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
             }
             updateHideTouchControls()
         
-        volume.barTintColor = .white
-        volume.barBackgroundColor = UIColor.white.withAlphaComponent(0.3)
-        volume.animation = .slideDown
-        view.addSubview(volume)
+        if PVSettingsModel.shared.volumeHUD {
+            volume.barTintColor = .white
+            volume.barBackgroundColor = UIColor.white.withAlphaComponent(0.3)
+            volume.animation = .slideDown
+            view.addSubview(volume)
+        }
         
         NotificationCenter.default.addObserver(volume, selector: #selector(SubtleVolume.resume), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
         
@@ -232,6 +237,7 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
                 rightShoulderButton?.isHidden = false
                 leftShoulderButton2?.isHidden = false
                 rightShoulderButton2?.isHidden = false
+                zTriggerButton?.isHidden = false
                 startButton?.isHidden = false
                 selectButton?.isHidden = false
             }
@@ -255,6 +261,7 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
                 rightShoulderButton?.isHidden = false
                 leftShoulderButton2?.isHidden = false
                 rightShoulderButton2?.isHidden = false
+                zTriggerButton?.isHidden = false
                 startButton?.isHidden = false
                 selectButton?.isHidden = false
             }
@@ -299,7 +306,9 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
         super.viewDidLayoutSubviews()
         setupTouchControls()
         layoutViews()
-        layoutVolume()
+        if PVSettingsModel.shared.volumeHUD {
+            layoutVolume()
+        }
         updateHideTouchControls()
     }
     
@@ -322,6 +331,7 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
         rightShoulderButton?.isHidden = true
         leftShoulderButton2?.isHidden = true
         rightShoulderButton2?.isHidden = true
+        zTriggerButton?.isHidden = true
 
         //Game Boy, Game Color, and Game Boy Advance can map Start and Select on a Standard Gamepad, so it's safe to hide them
         let useStandardGamepad: [SystemIdentifier] = [.GB, .GBC, .GBA]
@@ -391,7 +401,7 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
                     let bottomPadding: CGFloat = 16
                     let buttonsOriginY: CGFloat = min(controlOriginY - bottomPadding, view.frame.height - controlSize.height - bottomPadding)
                     let buttonsFrame = CGRect(x: view.bounds.maxX - controlSize.width - xPadding, y: buttonsOriginY, width: controlSize.width, height: controlSize.height)
-
+                    
                     if let buttonGroup = self.buttonGroup {
                         buttonGroup.frame = buttonsFrame
                     } else {
@@ -424,30 +434,122 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
                         buttonGroup.alpha = alpha
                         view.addSubview(buttonGroup)
                     }
-                } else if (controlType == Keys.LeftShoulderButton) {
-                    layoutLeftShoulderButtons(control: control)
                 } else if (controlType == Keys.RightShoulderButton) {
                     layoutRightShoulderButtons(control: control)
-                } else if (controlType == Keys.StartButton) {
-                    layoutStartButton(control: control)
+                } else if (controlType == Keys.ZTriggerButton) {
+                    layoutZTriggerButton(control: control)
+                } else if (controlType == Keys.LeftShoulderButton) {
+                    layoutLeftShoulderButtons(control: control)
                 } else if (controlType == Keys.SelectButton) {
                     layoutSelectButton(control: control)
+                } else if (controlType == Keys.StartButton) {
+                    layoutStartButton(control: control)
                 }
             }
         #endif
     }
 
     #if os(iOS)
+    func layoutRightShoulderButtons(control: ControlLayoutEntry) {
+        let controlSize: CGSize = CGSizeFromString(control.PVControlSize)
+        let xPadding: CGFloat = safeAreaInsets.right + 10
+        let yPadding: CGFloat = safeAreaInsets.bottom + 10
+        var rightShoulderFrame: CGRect!
+        
+        if (buttonGroup != nil) && !(buttonGroup?.isHidden)! {
+            rightShoulderFrame = CGRect(x: view.frame.size.width - controlSize.width - xPadding, y: (buttonGroup?.frame.minY)! - (controlSize.height * 2) - 4, width: controlSize.width, height: controlSize.height)
+        } else {
+            rightShoulderFrame = CGRect(x: view.frame.size.width - controlSize.width - xPadding, y: view.frame.size.height - (controlSize.height * 2) - yPadding, width: controlSize.width, height: controlSize.height)
+        }
+        
+        if rightShoulderButton == nil {
+            let rightShoulderButton = JSButton(frame: rightShoulderFrame)
+            if let tintColor = control.PVControlTint {
+                rightShoulderButton.tintColor = UIColor(hex: tintColor)
+            }
+            self.rightShoulderButton = rightShoulderButton
+            rightShoulderButton.titleLabel?.text = control.PVControlTitle
+            rightShoulderButton.titleLabel?.font = UIFont.systemFont(ofSize: 9)
+            rightShoulderButton.backgroundImage = UIImage(named: "button-thin")
+            rightShoulderButton.backgroundImagePressed = UIImage(named: "button-thin-pressed")
+            rightShoulderButton.delegate = self
+            rightShoulderButton.titleEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 4, right: 2)
+            rightShoulderButton.alpha = alpha
+            rightShoulderButton.autoresizingMask = [.flexibleBottomMargin, .flexibleLeftMargin]
+            view.addSubview(rightShoulderButton)
+        } else if rightShoulderButton2 == nil, let title = control.PVControlTitle, title == "R2" {
+            let rightShoulderButton2 = JSButton(frame: rightShoulderFrame)
+            if let tintColor = control.PVControlTint {
+                rightShoulderButton2.tintColor = UIColor(hex: tintColor)
+            }
+            self.rightShoulderButton2 = rightShoulderButton2
+            rightShoulderButton2.titleLabel?.text = control.PVControlTitle
+            rightShoulderButton2.titleLabel?.font = UIFont.systemFont(ofSize: 9)
+            rightShoulderButton2.backgroundImage = UIImage(named: "button-thin")
+            rightShoulderButton2.backgroundImagePressed = UIImage(named: "button-thin-pressed")
+            rightShoulderButton2.delegate = self
+            rightShoulderButton2.titleEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 4, right: 2)
+            rightShoulderButton2.alpha = alpha
+            rightShoulderButton2.autoresizingMask = [.flexibleBottomMargin, .flexibleLeftMargin]
+            rightShoulderFrame.origin.y += controlSize.height
+            view.addSubview(rightShoulderButton2)
+        } else {
+            rightShoulderButton2?.frame = rightShoulderFrame
+            rightShoulderFrame.origin.y += rightShoulderButton!.frame.size.height
+            rightShoulderButton?.frame = rightShoulderFrame
+        }
+    }
+    
+    func layoutZTriggerButton(control: ControlLayoutEntry) {
+        let controlSize: CGSize = CGSizeFromString(control.PVControlSize)
+        let xPadding: CGFloat = safeAreaInsets.right + 10
+        let yPadding: CGFloat = safeAreaInsets.bottom + 10
+        var zTriggerFrame: CGRect!
+        
+        if rightShoulderButton != nil {
+            zTriggerFrame = CGRect(x: (rightShoulderButton?.frame.minX)! - controlSize.width, y: (rightShoulderButton?.frame.minY)!, width: controlSize.width, height: controlSize.height)
+        } else {
+            zTriggerFrame = CGRect(x: view.frame.size.width - (controlSize.width * 2) - xPadding, y: view.frame.size.height - (controlSize.height * 2)
+                - yPadding, width: controlSize.width, height: controlSize.height)
+        }
+
+        if let zTriggerButton = self.zTriggerButton {
+            zTriggerButton.frame = zTriggerFrame
+        } else {
+            let zTriggerButton = JSButton(frame: zTriggerFrame)
+            if let tintColor = control.PVControlTint {
+                zTriggerButton.tintColor = UIColor(hex: tintColor)
+            }
+            self.zTriggerButton = zTriggerButton
+            zTriggerButton.titleLabel?.text = control.PVControlTitle
+            zTriggerButton.titleLabel?.font = UIFont.systemFont(ofSize: 9)
+            zTriggerButton.backgroundImage = UIImage(named: "button-thin")
+            zTriggerButton.backgroundImagePressed = UIImage(named: "button-thin-pressed")
+            zTriggerButton.delegate = self
+            zTriggerButton.titleEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 4, right: 2)
+            zTriggerButton.alpha = alpha
+            zTriggerButton.autoresizingMask = [.flexibleBottomMargin, .flexibleLeftMargin]
+            view.addSubview(zTriggerButton)
+        }
+    }
+    
     func layoutLeftShoulderButtons(control: ControlLayoutEntry) {
         let controlSize: CGSize = CGSizeFromString(control.PVControlSize)
         let xPadding: CGFloat = safeAreaInsets.left + 10
         let yPadding: CGFloat = safeAreaInsets.bottom + 10
-        var leftShoulderFrame = CGRect(x: xPadding, y: view.frame.size.height - (controlSize.height * 2) - yPadding, width: controlSize.width, height: controlSize.height)
-        
-        if (dPad != nil) && !(dPad?.isHidden)! {
-            leftShoulderFrame.origin.y = (dPad?.frame.origin.y)! - (dPad?.frame.height)! / 2
+        var leftShoulderFrame: CGRect!
+        if (buttonGroup != nil) && !(buttonGroup?.isHidden)! {
+            leftShoulderFrame = CGRect(x: xPadding, y: (buttonGroup?.frame.minY)! - (controlSize.height * 2) - 4, width: controlSize.width, height: controlSize.height)
         } else {
-            leftShoulderFrame.origin.y = yPadding
+            leftShoulderFrame = CGRect(x: xPadding, y: view.frame.size.height - (controlSize.height * 2) - yPadding, width: controlSize.width, height: controlSize.height)
+        }
+        
+        if PVSettingsModel.shared.allRightShoulders {
+            if zTriggerButton != nil {
+                leftShoulderFrame.origin.x = (zTriggerButton?.frame.origin.x)! - controlSize.width
+            } else if zTriggerButton == nil && rightShoulderButton != nil {
+                leftShoulderFrame.origin.x = (rightShoulderButton?.frame.origin.x)! - controlSize.width
+            }
         }
         
         if leftShoulderButton == nil {
@@ -484,120 +586,27 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
             
         } else {
             leftShoulderButton2?.frame = leftShoulderFrame
-            leftShoulderFrame.origin.y += leftShoulderButton!.frame.size.height + 5
+            leftShoulderFrame.origin.y += leftShoulderButton!.frame.size.height
             leftShoulderButton?.frame = leftShoulderFrame
         }
     }
     
-    func layoutRightShoulderButtons(control: ControlLayoutEntry) {
-        let controlSize: CGSize = CGSizeFromString(control.PVControlSize)
-        let xPadding: CGFloat = safeAreaInsets.right + 10
-        let yPadding: CGFloat = safeAreaInsets.bottom + 10
-        var rightShoulderFrame = CGRect(x: view.frame.size.width - controlSize.width - xPadding, y: view.frame.size.height - (controlSize.height * 2)  - yPadding, width: controlSize.width, height: controlSize.height)
-        
-        if (buttonGroup != nil) && !(buttonGroup?.isHidden)! {
-            rightShoulderFrame.origin.y = (buttonGroup?.frame.origin.y)! - (buttonGroup?.frame.height)! / 2
-        }
-        
-        if rightShoulderButton == nil {
-            let rightShoulderButton = JSButton(frame: rightShoulderFrame)
-            if let tintColor = control.PVControlTint {
-                rightShoulderButton.tintColor = UIColor(hex: tintColor)
-            }
-            self.rightShoulderButton = rightShoulderButton
-            rightShoulderButton.titleLabel?.text = control.PVControlTitle
-            rightShoulderButton.titleLabel?.font = UIFont.systemFont(ofSize: 9)
-            rightShoulderButton.backgroundImage = UIImage(named: "button-thin")
-            rightShoulderButton.backgroundImagePressed = UIImage(named: "button-thin-pressed")
-            rightShoulderButton.delegate = self
-            rightShoulderButton.titleEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 4, right: 2)
-            rightShoulderButton.alpha = alpha
-            rightShoulderButton.autoresizingMask = [.flexibleBottomMargin, .flexibleLeftMargin]
-            view.addSubview(rightShoulderButton)
-        } else if rightShoulderButton2 == nil, let title = control.PVControlTitle, title == "R2"{
-            let rightShoulderButton2 = JSButton(frame: rightShoulderFrame)
-            if let tintColor = control.PVControlTint {
-                rightShoulderButton2.tintColor = UIColor(hex: tintColor)
-            }
-            self.rightShoulderButton2 = rightShoulderButton2
-            rightShoulderButton2.titleLabel?.text = control.PVControlTitle
-            rightShoulderButton2.titleLabel?.font = UIFont.systemFont(ofSize: 9)
-            rightShoulderButton2.backgroundImage = UIImage(named: "button-thin")
-            rightShoulderButton2.backgroundImagePressed = UIImage(named: "button-thin-pressed")
-            rightShoulderButton2.delegate = self
-            rightShoulderButton2.titleEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 4, right: 2)
-            rightShoulderButton2.alpha = alpha
-            rightShoulderButton2.autoresizingMask = [.flexibleBottomMargin, .flexibleLeftMargin]
-            rightShoulderFrame.origin.y += controlSize.height
-            view.addSubview(rightShoulderButton2)
-        } else {
-            rightShoulderButton2?.frame = rightShoulderFrame
-            rightShoulderFrame.origin.y += rightShoulderButton!.frame.size.height + 5
-            rightShoulderButton?.frame = rightShoulderFrame
-        }
-    }
-    
-    func layoutStartButton(control: ControlLayoutEntry) {
-        let controlSize: CGSize = CGSizeFromString(control.PVControlSize)
-        let yPadding: CGFloat = safeAreaInsets.bottom + 10
-        let xPadding: CGFloat = safeAreaInsets.right + 10
-        let xSpacing: CGFloat = 20
-        var startFrame: CGRect!
-        if super.view.bounds.size.width > super.view.bounds.size.height || UIDevice.current.orientation.isLandscape || UIDevice.current.userInterfaceIdiom == .pad  {
-            if (buttonGroup != nil) && !(buttonGroup?.isHidden)! {
-                startFrame = CGRect(x: (buttonGroup?.frame.origin.x)! - controlSize.width + (controlSize.width / 2), y: (buttonGroup?.frame.origin.y)! + (buttonGroup?.frame.height)! - controlSize.height, width: controlSize.width, height: controlSize.height)
-            } else if (buttonGroup != nil) && (buttonGroup?.isHidden)! {
-                startFrame = CGRect(x: view.frame.size.width - controlSize.width - xPadding, y: view.frame.height - yPadding - controlSize.height, width: controlSize.width, height: controlSize.height)
-            } else {
-                startFrame = CGRect(x: view.frame.size.width - controlSize.width - xPadding, y: view.frame.height - yPadding - controlSize.height, width: controlSize.width, height: controlSize.height)
-            }
-        } else if super.view.bounds.size.width < super.view.bounds.size.height || UIDevice.current.orientation.isPortrait {
-            startFrame = CGRect(x: (view.frame.size.width / 2) + (xSpacing / 2), y: (buttonGroup?.frame.origin.y)! + (buttonGroup?.frame.height)! + yPadding, width: controlSize.width, height: controlSize.height)
-        } else {
-            startFrame = CGRect(x: view.frame.size.width - controlSize.width - xPadding, y: view.frame.height - yPadding - controlSize.height, width: controlSize.width, height: controlSize.height)
-        }
-
-        if let startButton = self.startButton {
-            startButton.frame = startFrame
-        } else {
-            let startButton = JSButton(frame: startFrame)
-            if let tintColor = control.PVControlTint {
-                startButton.tintColor = UIColor(hex: tintColor)
-            }
-            self.startButton = startButton
-            startButton.titleLabel?.text = control.PVControlTitle
-            startButton.titleLabel?.font = UIFont.systemFont(ofSize: 9)
-            startButton.backgroundImage = UIImage(named: "button-thin")
-            startButton.backgroundImagePressed = UIImage(named: "button-thin-pressed")
-            startButton.delegate = self
-            startButton.titleEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 4, right: 2)
-            startButton.alpha = alpha
-            startButton.autoresizingMask = [.flexibleTopMargin, .flexibleLeftMargin, .flexibleRightMargin]
-            view.addSubview(startButton)
-        }
-    }
-
     func layoutSelectButton( control: ControlLayoutEntry ) {
         let controlSize: CGSize = CGSizeFromString(control.PVControlSize)
         let yPadding: CGFloat = safeAreaInsets.bottom + 10
         let xPadding: CGFloat = safeAreaInsets.left + 10
-        let xSpacing: CGFloat = 20
-        var selectFrame: CGRect!
+        let spacing: CGFloat = 20
+        var selectFrame = CGRect(x: xPadding, y: view.frame.height - yPadding - controlSize.height, width: controlSize.width, height: controlSize.height)
+        
         if super.view.bounds.size.width > super.view.bounds.size.height || UIDevice.current.orientation.isLandscape || UIDevice.current.userInterfaceIdiom == .pad {
             if (dPad != nil) && !(dPad?.isHidden)! {
-                selectFrame = CGRect(x: (dPad?.frame.origin.x)! + (dPad?.frame.size.width)! - (controlSize.width / 2), y: (buttonGroup?.frame.origin.y)! + (buttonGroup?.frame.height)! - controlSize.height, width: controlSize.width, height: controlSize.height)
+                selectFrame = CGRect(x: (dPad?.frame.origin.x)! + (dPad?.frame.size.width)! - (controlSize.width / 3), y: (buttonGroup?.frame.maxY)! - controlSize.height, width: controlSize.width, height: controlSize.height)
             } else if (dPad != nil) && (dPad?.isHidden)! {
-                selectFrame = CGRect(x: xPadding, y: view.frame.height - yPadding - controlSize.height, width: controlSize.width, height: controlSize.height)
-            } else {
                 selectFrame = CGRect(x: xPadding, y: view.frame.height - yPadding - controlSize.height, width: controlSize.width, height: controlSize.height)
             }
 
         } else if super.view.bounds.size.width < super.view.bounds.size.height || UIDevice.current.orientation.isPortrait {
-			let x: CGFloat = (view.frame.size.width / CGFloat(2.0)) - controlSize.width - (xSpacing / CGFloat(2.0))
-			let y: CGFloat = ((buttonGroup?.frame.origin.y) ?? 0) + (buttonGroup?.frame.height)! + yPadding
-            selectFrame = CGRect(x: x, y: y, width: controlSize.width, height: controlSize.height)
-        } else {
-                selectFrame = CGRect(x: xPadding, y: view.frame.height - yPadding - controlSize.height, width: controlSize.width, height: controlSize.height)
+            selectFrame = CGRect(x: (view.frame.size.width / 2) - controlSize.width - (spacing / 2), y: (buttonGroup?.frame.maxY)! + spacing, width: controlSize.width, height: controlSize.height)
         }
         
         if let selectButton = self.selectButton {
@@ -619,5 +628,45 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
             view.addSubview(selectButton)
         }
     }
+    
+    func layoutStartButton(control: ControlLayoutEntry) {
+        let controlSize: CGSize = CGSizeFromString(control.PVControlSize)
+        let yPadding: CGFloat = safeAreaInsets.bottom + 10
+        let xPadding: CGFloat = safeAreaInsets.right + 10
+        let spacing: CGFloat = 20
+        var startFrame = CGRect(x: view.frame.size.width - controlSize.width - xPadding, y: view.frame.height - yPadding - controlSize.height, width: controlSize.width, height: controlSize.height)
+        
+        if super.view.bounds.size.width > super.view.bounds.size.height || UIDevice.current.orientation.isLandscape || UIDevice.current.userInterfaceIdiom == .pad  {
+                startFrame = CGRect(x: (buttonGroup?.frame.origin.x)! - controlSize.width + (controlSize.width / 3), y: (buttonGroup?.frame.maxY)! - controlSize.height, width: controlSize.width, height: controlSize.height)
+                if system.shortName == "SG" || system.shortName == "SCD" || system.shortName == "32X" {
+                    startFrame.origin.x -= (controlSize.width / 2)
+                }
+        } else if super.view.bounds.size.width < super.view.bounds.size.height || UIDevice.current.orientation.isPortrait {
+            startFrame = CGRect(x: (view.frame.size.width / 2) + (spacing / 2), y: (buttonGroup?.frame.maxY)! + spacing, width: controlSize.width, height: controlSize.height)
+            if selectButton == nil {
+                startFrame.origin.x -= (spacing / 2) + (controlSize.width / 2)
+            }
+        }
+        
+        if let startButton = self.startButton {
+            startButton.frame = startFrame
+        } else {
+            let startButton = JSButton(frame: startFrame)
+            if let tintColor = control.PVControlTint {
+                startButton.tintColor = UIColor(hex: tintColor)
+            }
+            self.startButton = startButton
+            startButton.titleLabel?.text = control.PVControlTitle
+            startButton.titleLabel?.font = UIFont.systemFont(ofSize: 9)
+            startButton.backgroundImage = UIImage(named: "button-thin")
+            startButton.backgroundImagePressed = UIImage(named: "button-thin-pressed")
+            startButton.delegate = self
+            startButton.titleEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 4, right: 2)
+            startButton.alpha = alpha
+            startButton.autoresizingMask = [.flexibleTopMargin, .flexibleLeftMargin, .flexibleRightMargin]
+            view.addSubview(startButton)
+        }
+    }
+    
     #endif
 }

--- a/Provenance/Controller/PVN64ControllerViewController.swift
+++ b/Provenance/Controller/PVN64ControllerViewController.swift
@@ -52,7 +52,7 @@ class PVN64ControllerViewController: PVControllerViewController<PVN64SystemRespo
 
         leftShoulderButton?.buttonTag = .l
         rightShoulderButton?.buttonTag = .r
-        selectButton?.buttonTag = .z
+        zTriggerButton?.buttonTag = .z
         startButton?.buttonTag = .start
     }
 
@@ -111,14 +111,5 @@ class PVN64ControllerViewController: PVControllerViewController<PVN64SystemRespo
 
     override func releaseStart(forPlayer player: Int) {
         emulatorCore.didRelease(.start, forPlayer: player)
-    }
-
-    override func pressSelect(forPlayer player: Int) {
-        emulatorCore.didPush(.z, forPlayer: player)
-        vibrate()
-    }
-
-    override func releaseSelect(forPlayer player: Int) {
-        emulatorCore.didRelease(.z, forPlayer: player)
     }
 }

--- a/Provenance/Emulator/PVEmulatorConfiguration.swift
+++ b/Provenance/Emulator/PVEmulatorConfiguration.swift
@@ -38,6 +38,7 @@ public struct SystemDictionaryKeys {
         static let GroupedButtons      = "PVGroupedButtons"
         static let LeftShoulderButton  = "PVLeftShoulderButton"
         static let RightShoulderButton = "PVRightShoulderButton"
+        static let ZTriggerButton      = "PVZTriggerButton"
         static let SelectButton        = "PVSelectButton"
         static let StartButton         = "PVStartButton"
     }

--- a/Provenance/Resources/systems.plist
+++ b/Provenance/Resources/systems.plist
@@ -115,14 +115,6 @@
 			</dict>
 			<dict>
 				<key>PVControlType</key>
-				<string>PVSelectButton</string>
-				<key>PVControlTitle</key>
-				<string>Z</string>
-				<key>PVControlSize</key>
-				<string>{60,42}</string>
-			</dict>
-			<dict>
-				<key>PVControlType</key>
 				<string>PVLeftShoulderButton</string>
 				<key>PVControlTitle</key>
 				<string>L</string>
@@ -134,6 +126,14 @@
 				<string>PVRightShoulderButton</string>
 				<key>PVControlTitle</key>
 				<string>R</string>
+				<key>PVControlSize</key>
+				<string>{60,42}</string>
+			</dict>
+			<dict>
+				<key>PVControlType</key>
+				<string>PVZTriggerButton</string>
+				<key>PVControlTitle</key>
+				<string>Z</string>
 				<key>PVControlSize</key>
 				<string>{60,42}</string>
 			</dict>

--- a/Provenance/Settings/PVSettingsModel.swift
+++ b/Provenance/Settings/PVSettingsModel.swift
@@ -27,6 +27,8 @@ let kWebDayAlwwaysOnKey = "kWebDavAlwaysOnKey"
 let kThemeKey = "kThemeKey"
 let kButtonTintsKey = "kButtonsTintsKey"
 let kStartSelectAlwaysOnKey = "kStartSelectAlwaysOnKey"
+let kAllRightShouldersKey = "kAllRightShouldersKey"
+let kVolumeHUDKey = "kVolumeHUDKey"
 
 public class PVSettingsModel: NSObject {
 
@@ -160,9 +162,25 @@ public class PVSettingsModel: NSObject {
     }
 
     @objc
+    var allRightShoulders: Bool {
+        didSet {
+            UserDefaults.standard.set(allRightShoulders, forKey: kAllRightShouldersKey)
+            UserDefaults.standard.synchronize()
+        }
+    }
+    
+    @objc
     var volume: Float {
         didSet {
             UserDefaults.standard.set(volume, forKey: kVolumeSettingKey)
+            UserDefaults.standard.synchronize()
+        }
+    }
+    
+    @objc
+    var volumeHUD: Bool {
+        didSet {
+            UserDefaults.standard.set(volumeHUD, forKey: kVolumeHUDKey)
             UserDefaults.standard.synchronize()
         }
     }
@@ -205,8 +223,10 @@ public class PVSettingsModel: NSObject {
                                                   kFPSCountKey: false,
                                                   kShowGameTitlesKey: true,
                                                   kWebDayAlwwaysOnKey: false,
-                                                  kButtonTintsKey: true,
+                                                  kButtonTintsKey: false,
                                                   kStartSelectAlwaysOnKey: false,
+                                                  kAllRightShouldersKey: false,
+                                                  kVolumeHUDKey: true,
                                                   kThemeKey: theme])
         UserDefaults.standard.synchronize()
 
@@ -228,6 +248,8 @@ public class PVSettingsModel: NSObject {
         askToAutoLoad = UserDefaults.standard.bool(forKey: kAskToAutoLoadKey)
         buttonTints = UserDefaults.standard.bool(forKey: kButtonTintsKey)
         startSelectAlwaysOn = UserDefaults.standard.bool(forKey: kStartSelectAlwaysOnKey)
+        allRightShoulders = UserDefaults.standard.bool(forKey: kAllRightShouldersKey)
+        volumeHUD = UserDefaults.standard.bool(forKey: kVolumeHUDKey)
 
         #if os(iOS)
         let themeString = UserDefaults.standard.string(forKey: kThemeKey) ?? Themes.defaultTheme.rawValue

--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -42,7 +42,8 @@ class PVSettingsViewController: UITableViewController, SFSafariViewControllerDel
     @IBOutlet weak var importLabel: UILabel!
     @IBOutlet weak var tintSwitch: UISwitch!
     @IBOutlet weak var startSelectSwitch: UISwitch!
-
+    @IBOutlet weak var volumeHUDSwitch: UISwitch!
+    @IBOutlet weak var allRightShouldersSwitch: UISwitch!
     @IBOutlet weak var themeValueLabel: UILabel!
 
     var gameImporter: PVGameImporter?
@@ -78,6 +79,8 @@ class PVSettingsViewController: UITableViewController, SFSafariViewControllerDel
         fpsCountSwitch.isOn = settings.showFPSCount
         tintSwitch.isOn = settings.buttonTints
         startSelectSwitch.isOn = settings.startSelectAlwaysOn
+        allRightShouldersSwitch.isOn = settings.allRightShoulders
+        volumeHUDSwitch.isOn = settings.volumeHUD
         volumeSlider.value = settings.volume
         volumeValueLabel.text = String(format: "%.0f%%", volumeSlider.value * 100)
         opacityValueLabel.text = String(format: "%.0f%%", opacitySlider.value * 100)
@@ -179,8 +182,17 @@ class PVSettingsViewController: UITableViewController, SFSafariViewControllerDel
     }
 
     @IBAction func toggleStartSelectAlwaysOn(_ sender: Any) {
-              PVSettingsModel.sharedInstance().startSelectAlwaysOn = startSelectSwitch.isOn
+        PVSettingsModel.sharedInstance().startSelectAlwaysOn = startSelectSwitch.isOn
     }
+    
+    @IBAction func toggleVolumeHUD(_ sender: Any) {
+        PVSettingsModel.sharedInstance().volumeHUD = volumeHUDSwitch.isOn
+    }
+    
+    @IBAction func toggleAllRightShoulders(_ sender: Any) {
+        PVSettingsModel.sharedInstance().allRightShoulders = allRightShouldersSwitch.isOn
+    }
+    
 
     // Show web server (stays on)
     @available(iOS 9.0, *)
@@ -241,7 +253,7 @@ class PVSettingsViewController: UITableViewController, SFSafariViewControllerDel
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if indexPath.section == 2 && indexPath.row == 5 {
+        if indexPath.section == 2 && indexPath.row == 6 {
             let iCadeControllerViewController = PViCadeControllerViewController()
             navigationController?.pushViewController(iCadeControllerViewController, animated: true)
         } else if indexPath.section == 3 && indexPath.row == 0 {

--- a/Provenance/User Interface/Provenance.storyboard
+++ b/Provenance/User Interface/Provenance.storyboard
@@ -367,7 +367,7 @@
                             </connections>
                         </barButtonItem>
                         <textField key="titleView" opaque="NO" clipsSubviews="YES" contentMode="redraw" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" text="Search" borderStyle="roundedRect" placeholder="Search" textAlignment="center" minimumFontSize="17" clearButtonMode="always" id="FMl-Ia-DzO">
-                            <rect key="frame" x="87" y="7" width="202" height="30"/>
+                            <rect key="frame" x="86.666666666666686" y="7" width="202" height="30"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="0.25159489197863472" alpha="0.1543771404109589" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <color key="textColor" white="0.80292426215277779" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -596,7 +596,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="PUr-Ht-uuQ">
+                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="PUr-Ht-uuQ">
                                                     <rect key="frame" x="305" y="7" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                     <color key="onTintColor" red="0.0" green="0.48024823589999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -621,7 +621,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="9MJ-nj-MVv">
+                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="9MJ-nj-MVv">
                                                     <rect key="frame" x="306" y="7" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                     <color key="onTintColor" red="0.0" green="0.48024823589999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -674,14 +674,39 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="n01-dp-kuF" userLabel="CRT Filter">
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="o9e-Nz-mQW" userLabel="Volume HUD">
                                         <rect key="frame" x="0.0" y="265" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="o9e-Nz-mQW" id="aXP-nf-uBe">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="fzi-7p-hKL" userLabel="Volume HUD Switch">
+                                                    <rect key="frame" x="305" y="7" width="51" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                                                    <color key="onTintColor" red="0.0" green="0.48024823589999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <connections>
+                                                        <action selector="toggleVolumeHUD:" destination="bcR-zD-bPX" eventType="valueChanged" id="izp-Cz-Tp6"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Volume HUD" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="LRG-Fg-uAd">
+                                                    <rect key="frame" x="16" y="8" width="263" height="27"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="n01-dp-kuF" userLabel="CRT Filter">
+                                        <rect key="frame" x="0.0" y="309" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="n01-dp-kuF" id="pGk-BZ-YlW">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="6Z6-Cv-rpv" userLabel="CRT Filter Switch">
+                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="6Z6-Cv-rpv" userLabel="CRT Filter Switch">
                                                     <rect key="frame" x="306" y="7" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                     <color key="onTintColor" red="0.0" green="0.48024823589999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -700,13 +725,13 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="KFu-Sm-ywF" userLabel="Image Smoothing">
-                                        <rect key="frame" x="0.0" y="309" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="353" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KFu-Sm-ywF" id="sEH-EL-RuC">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="STq-Oc-Ybf">
+                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="STq-Oc-Ybf">
                                                     <rect key="frame" x="306" y="7" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                     <color key="onTintColor" red="0.0" green="0.48024823589999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -725,13 +750,13 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="VWs-2d-AL1" userLabel="FPS Counter">
-                                        <rect key="frame" x="0.0" y="353" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="397" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="VWs-2d-AL1" id="Q3h-r5-UwT">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="Khw-VR-sw0">
+                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="Khw-VR-sw0">
                                                     <rect key="frame" x="305" y="7" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                     <color key="onTintColor" red="0.0" green="0.48024823589999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -754,7 +779,7 @@
                             <tableViewSection headerTitle="Controller" id="L0J-7O-0ta" userLabel="Controller">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" misplaced="YES" selectionStyle="none" indentationWidth="10" rowHeight="54" id="e1a-PZ-eJ1" userLabel="Opacity">
-                                        <rect key="frame" x="0.0" y="445" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="489" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="e1a-PZ-eJ1" id="tOK-UT-cy2">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="53.666666666666664"/>
@@ -785,13 +810,13 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="hVr-fd-tUR" userLabel="Button Colors">
-                                        <rect key="frame" x="0.0" y="499" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="543" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="hVr-fd-tUR" id="xZC-39-gnG">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="duB-ZD-Sja" userLabel="Tint Switch">
+                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="duB-ZD-Sja" userLabel="Tint Switch">
                                                     <rect key="frame" x="305" y="7" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                     <color key="onTintColor" red="0.0" green="0.48024823589999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -810,7 +835,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="54" id="6xF-Re-IEM" userLabel="Start/Select Always On">
-                                        <rect key="frame" x="0.0" y="543" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="587" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="6xF-Re-IEM" id="mNR-MR-cEX">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="53.666666666666664"/>
@@ -841,8 +866,40 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="54" id="bie-He-o1C" userLabel="All-Right Shoulders">
+                                        <rect key="frame" x="0.0" y="641" width="375" height="54"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bie-He-o1C" id="nIg-Aj-5Wp">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="53.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="All-Right Shoulders" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" id="LPd-fr-b7s">
+                                                    <rect key="frame" x="16" y="7" width="277" height="27"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" misplaced="YES" text="Moves L1, L2, and Z to right side" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pLB-LY-qR3">
+                                                    <rect key="frame" x="16" y="30.999999999999886" width="157" height="12"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="sds-2b-M52" userLabel="Rightside Switch">
+                                                    <rect key="frame" x="305" y="12" width="51" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                                                    <color key="onTintColor" red="0.0" green="0.48024823589999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <connections>
+                                                        <action selector="toggleAllRightShoulders:" destination="bcR-zD-bPX" eventType="valueChanged" id="7YG-Jj-YWD"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="nNw-4E-ySi" userLabel="Taptic Feedback">
-                                        <rect key="frame" x="0.0" y="597" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="695" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nNw-4E-ySi" id="hT5-5b-CPT">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
@@ -867,23 +924,23 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="8hH-1M-Xm1" detailTextLabel="wUr-5z-cUs" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="m8C-LM-tq3" userLabel="Controller Selection">
-                                        <rect key="frame" x="0.0" y="641" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="739" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="m8C-LM-tq3" id="idp-7Q-cw7">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="53.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Controller Selection" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8hH-1M-Xm1">
-                                                    <rect key="frame" x="16" y="9.9999999999999982" width="151" height="20.333333333333332"/>
+                                                    <rect key="frame" x="16" y="10.999999999999998" width="151" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Choose which controller players use" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wUr-5z-cUs">
-                                                    <rect key="frame" x="16" y="30.333333333333332" width="204.66666666666666" height="14.333333333333334"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" misplaced="YES" text="Choose which controller players use" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wUr-5z-cUs">
+                                                    <rect key="frame" x="16" y="31.333333333333329" width="174.66666666666666" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -894,23 +951,23 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="GoG-Nc-lcT" detailTextLabel="9zw-Ki-2kr" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="5on-3K-Yj7" userLabel="iCade Controller">
-                                        <rect key="frame" x="0.0" y="695" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="793" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="5on-3K-Yj7" id="PyC-mb-I4L">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="53.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" misplaced="YES" preservesSuperviewLayoutMargins="YES" text="iCade Controller" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GoG-Nc-lcT">
-                                                    <rect key="frame" x="16" y="9.9999999999999982" width="124" height="20.333333333333332"/>
+                                                    <rect key="frame" x="16" y="10.999999999999998" width="124" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" text="Disabled" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9zw-Ki-2kr">
-                                                    <rect key="frame" x="16.000000000000004" y="30.333333333333332" width="49.333333333333336" height="14.333333333333334"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" misplaced="YES" preservesSuperviewLayoutMargins="YES" text="Disabled" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9zw-Ki-2kr">
+                                                    <rect key="frame" x="16" y="31.333333333333329" width="42" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -922,23 +979,23 @@
                             <tableViewSection headerTitle="Actions" id="z1f-5r-K1I" userLabel="Actions">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="m7A-Ve-3fQ" detailTextLabel="GAc-2H-eCw" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="fRu-A1-Mjc" userLabel="Import/Export Cell">
-                                        <rect key="frame" x="0.0" y="797" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="895" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fRu-A1-Mjc" id="ZKL-7A-ynJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="349" height="53.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="53.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" misplaced="YES" preservesSuperviewLayoutMargins="YES" text="Import/Export" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="m7A-Ve-3fQ">
-                                                    <rect key="frame" x="14.999999999999993" y="9.9999999999999982" width="106.33333333333333" height="20.333333333333332"/>
+                                                    <rect key="frame" x="14.999999999999993" y="10.999999999999998" width="106.33333333333333" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" text="Web server: upload/download ROMs, saves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GAc-2H-eCw">
-                                                    <rect key="frame" x="15.000000000000014" y="30.333333333333332" width="244.33333333333334" height="14.333333333333334"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" misplaced="YES" preservesSuperviewLayoutMargins="YES" text="Web server: upload/download ROMs, saves, cover art" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GAc-2H-eCw">
+                                                    <rect key="frame" x="15" y="31.333333333333329" width="257.66666666666669" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -947,7 +1004,7 @@
                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="AVF-iJ-dBV" userLabel="Import Note Cell">
-                                        <rect key="frame" x="0.0" y="851" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="949" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AVF-iJ-dBV" id="Maz-b3-i9d">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
@@ -956,21 +1013,28 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Upload multi-file ROMs as single-file .zip or .7z archives." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" id="jN6-ue-OrT">
                                                     <rect key="frame" x="16" y="7" width="343" height="15"/>
                                                     <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Check the wiki for more info about " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pfs-im-UIo">
-                                                    <rect key="frame" x="16" y="23" width="241" height="15"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="Check the wiki for more info about " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pfs-im-UIo">
+                                                    <rect key="frame" x="16" y="21" width="168" height="15"/>
                                                     <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="6Na-xW-iab">
-                                                    <rect key="frame" x="214" y="17" width="99" height="27"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tl2-6S-K8R">
+                                                    <rect key="frame" x="269" y="21" width="7" height="15"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="6Na-xW-iab">
+                                                    <rect key="frame" x="185" y="17" width="85" height="23"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <state key="normal" title="Formatting ROMs">
                                                         <color key="titleColor" red="0.00012962514299999999" green="0.47818720339999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -978,13 +1042,6 @@
                                                         <action selector="wikiLinkButton:" destination="bcR-zD-bPX" eventType="touchUpInside" id="zkg-Cp-zVH"/>
                                                     </connections>
                                                 </button>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hEU-og-bCB">
-                                                    <rect key="frame" x="306" y="23" width="5" height="15"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -993,7 +1050,7 @@
                                         </accessibility>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="1" id="lC2-hL-32t" userLabel="Dummy Cell">
-                                        <rect key="frame" x="0.0" y="895" width="375" height="1"/>
+                                        <rect key="frame" x="0.0" y="993" width="375" height="1"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lC2-hL-32t" id="nfa-Cu-nVa">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="0.66666666666666674"/>
@@ -1005,32 +1062,25 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Game Library" id="zDH-xT-eVR" userLabel="Game Library">
                                 <cells>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="atp-lT-0Aq" detailTextLabel="wBu-d7-8pS" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="Fne-jt-Shb">
-                                        <rect key="frame" x="0.0" y="944" width="375" height="54"/>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="atp-lT-0Aq" detailTextLabel="wBu-d7-8pS" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="Fne-jt-Shb" userLabel="Reresh Game Library">
+                                        <rect key="frame" x="0.0" y="1042" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Fne-jt-Shb" id="vXa-R1-bNz">
-                                            <rect key="frame" x="0.0" y="0.0" width="349" height="53.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="53.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" text="Refresh Game Library" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="atp-lT-0Aq">
-                                                    <rect key="frame" x="15" y="9.9999999999999982" width="166" height="20.333333333333332"/>
+                                                    <rect key="frame" x="16" y="10.999999999999998" width="166" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wBu-d7-8pS">
-                                                    <rect key="frame" x="15.000000000000014" y="30.333333333333332" width="251.33333333333334" height="14.333333333333334"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" misplaced="YES" preservesSuperviewLayoutMargins="YES" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wBu-d7-8pS">
+                                                    <rect key="frame" x="16" y="31.333333333333329" width="228" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <attributedString key="attributedText">
-                                                        <fragment content="Get artwork and titles again ">
-                                                            <attributes>
-                                                                <color key="NSColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <font key="NSFont" metaFont="cellTitle"/>
-                                                                <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                            </attributes>
-                                                        </fragment>
-                                                        <fragment content="(WARNING: SLOW)">
+                                                        <fragment content="Get artwork and titles again (WARNING: SLOW)">
                                                             <attributes>
                                                                 <color key="NSColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <font key="NSFont" size="10" name=".AppleSystemUIFont"/>
@@ -1043,56 +1093,56 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="IBC-zu-dJg" detailTextLabel="ifY-eR-QD5" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="lqy-4c-FqW">
-                                        <rect key="frame" x="0.0" y="998" width="375" height="54"/>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="IBC-zu-dJg" detailTextLabel="ifY-eR-QD5" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="lqy-4c-FqW" userLabel="Empty Image Cache">
+                                        <rect key="frame" x="0.0" y="1096" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lqy-4c-FqW" id="NvD-dI-vOW">
-                                            <rect key="frame" x="0.0" y="0.0" width="349" height="53.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="53.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" text="Empty Image Cache" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="IBC-zu-dJg">
-                                                    <rect key="frame" x="15" y="9.9999999999999982" width="153.33333333333334" height="20.333333333333332"/>
+                                                    <rect key="frame" x="16" y="10.999999999999998" width="153.33333333333334" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" text="Images will be redownloaded on demand" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ifY-eR-QD5">
-                                                    <rect key="frame" x="15.000000000000014" y="30.333333333333332" width="230.33333333333334" height="14.333333333333334"/>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" misplaced="YES" preservesSuperviewLayoutMargins="YES" text="Images will be redownloaded on demand" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ifY-eR-QD5">
+                                                    <rect key="frame" x="16" y="31.333333333333329" width="196.33333333333334" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="OiF-wU-8yr" detailTextLabel="iZ4-qo-Kdy" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="f5t-tV-SfE">
-                                        <rect key="frame" x="0.0" y="1052" width="375" height="54"/>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="OiF-wU-8yr" detailTextLabel="iZ4-qo-Kdy" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="f5t-tV-SfE" userLabel="Manage Conflicts">
+                                        <rect key="frame" x="0.0" y="1150" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="f5t-tV-SfE" id="iMU-bU-1Ql">
                                             <rect key="frame" x="0.0" y="0.0" width="349" height="53.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" text="Manage Conflicts" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="OiF-wU-8yr">
-                                                    <rect key="frame" x="15" y="9.9999999999999982" width="133.66666666666666" height="20.333333333333332"/>
+                                                    <rect key="frame" x="15" y="10.999999999999998" width="133.66666666666666" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" preservesSuperviewLayoutMargins="YES" text="Manually resolve conflicted imports" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iZ4-qo-Kdy">
-                                                    <rect key="frame" x="15" y="30.333333333333332" width="201" height="14.333333333333334"/>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" misplaced="YES" preservesSuperviewLayoutMargins="YES" text="Manually resolve conflicted imports" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iZ4-qo-Kdy">
+                                                    <rect key="frame" x="15" y="31.333333333333329" width="171.66666666666666" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" id="DMq-2a-EMZ">
-                                        <rect key="frame" x="0.0" y="1106" width="375" height="44"/>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" id="DMq-2a-EMZ" userLabel="Appearance">
+                                        <rect key="frame" x="0.0" y="1204" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="DMq-2a-EMZ" id="8yv-cl-P8T">
                                             <rect key="frame" x="0.0" y="0.0" width="349" height="43.666666666666664"/>
@@ -1116,7 +1166,7 @@
                             <tableViewSection headerTitle="Build Information" id="7wE-gr-KHM">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="bus-Zb-5mN" detailTextLabel="qSD-YJ-6LU" rowHeight="54" style="IBUITableViewCellStyleValue1" id="Dkv-aT-Qbm">
-                                        <rect key="frame" x="0.0" y="1198" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="1296" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Dkv-aT-Qbm" id="pWC-go-waY">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="53.666666666666664"/>
@@ -1141,7 +1191,7 @@
                                         <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="D2n-e2-WpK" detailTextLabel="m2L-ex-dJw" style="IBUITableViewCellStyleValue1" id="IHz-y5-D4m">
-                                        <rect key="frame" x="0.0" y="1252" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="1350" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="IHz-y5-D4m" id="FKo-Mo-pot">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
@@ -1166,7 +1216,7 @@
                                         <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="F5Y-Hw-2WS" detailTextLabel="yzB-Cf-bne" style="IBUITableViewCellStyleValue1" id="Zo8-xL-UZJ">
-                                        <rect key="frame" x="0.0" y="1296" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="1394" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Zo8-xL-UZJ" id="fWW-RW-fQt">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
@@ -1195,7 +1245,7 @@
                             <tableViewSection id="dBg-mA-kY6" userLabel="External Information">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" id="Pga-PU-Be3">
-                                        <rect key="frame" x="0.0" y="1360" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="1458" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Pga-PU-Be3" id="rQe-my-jux">
                                             <rect key="frame" x="0.0" y="0.0" width="349" height="43.666666666666664"/>
@@ -1215,7 +1265,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="y1X-37-OFg" rowHeight="54" style="IBUITableViewCellStyleDefault" id="TxB-hl-jAw">
-                                        <rect key="frame" x="0.0" y="1404" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="1502" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="TxB-hl-jAw" id="ZDB-Sl-QI6">
                                             <rect key="frame" x="0.0" y="0.0" width="349" height="53.666666666666664"/>
@@ -1258,6 +1308,7 @@
                     </navigationItem>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <connections>
+                        <outlet property="allRightShouldersSwitch" destination="sds-2b-M52" id="LOV-na-1uO"/>
                         <outlet property="autoLoadSwitch" destination="PUr-Ht-uuQ" id="rK4-bP-MZs"/>
                         <outlet property="autoLockSwitch" destination="9MJ-nj-MVv" id="yrI-Dw-wfR"/>
                         <outlet property="autoSaveSwitch" destination="9rq-wt-g02" id="2UV-gc-dYc"/>
@@ -1275,6 +1326,7 @@
                         <outlet property="tintSwitch" destination="duB-ZD-Sja" id="lD5-Pu-Byc"/>
                         <outlet property="versionLabel" destination="qSD-YJ-6LU" id="ynk-oD-ise"/>
                         <outlet property="vibrateSwitch" destination="sCY-Vf-abw" id="vws-BW-ehf"/>
+                        <outlet property="volumeHUDSwitch" destination="fzi-7p-hKL" id="As5-ti-VwH"/>
                         <outlet property="volumeSlider" destination="sIf-Ng-bjy" id="Qy2-ew-knK"/>
                         <outlet property="volumeValueLabel" destination="B5r-jT-vgt" id="GHV-j0-wNP"/>
                     </connections>


### PR DESCRIPTION
* missing project file updates for volume

* volume HUD toggle in settings

set to off by default until I can figure out if it’s the draw call that is actually causing latency or not… or if it was just a fluke after all

* volume HUD off now defers back to iOS volume

* Mednafen: Disable speculative video for snes

* Fix don’t ask which core for autosaves when core is known

Also made a new style for the option to always remember setting

* on-screen controller button layout fixes (N64, Sega, etc…)

- N64 Z button fix (new button type)
- N64 L/R button alignment
- L/R spacing finesse
- Sega 6x button / start button overlap fixed
- start/select distance fix (hopefully this helps people with older, shorter iPhones)

* new optional feature: All-Right Shoulders

pushes L1, L2, and Z to the right side, reassigning to Right Thumb (because on a touch-screen your left thumb is busy moving your character constantly).